### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/1369066793/e81c00e4-0612-41ba-81f7-e9f6b8386a26/3a1331fa-61fb-4076-9007-def93561e277/_apis/work/boardbadge/2f422cf7-46b5-4b2d-9c11-876f328de240)](https://dev.azure.com/1369066793/e81c00e4-0612-41ba-81f7-e9f6b8386a26/_boards/board/t/3a1331fa-61fb-4076-9007-def93561e277/Microsoft.RequirementCategory)
 # CPP
 这是 C++ 入门笔记


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/1369066793/e81c00e4-0612-41ba-81f7-e9f6b8386a26/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.